### PR TITLE
Improved vpn-openvpn-status so that it displays multiple vpns

### DIFF
--- a/polybar-scripts/vpn-openvpn-status/vpn-openvpn-status.sh
+++ b/polybar-scripts/vpn-openvpn-status/vpn-openvpn-status.sh
@@ -1,3 +1,11 @@
-#!/bin/sh
-
-printf "VPN: " && (pgrep -a openvpn$ | head -n 1 | awk '{print $NF }' | cut -d '.' -f 1 && echo down) | head -n 1
+#!/bin/env bash
+IFS=$'\n'
+out=""
+if [[ ! "$1" =~ "-noprefix" ]]; then
+    out="VPNs:";
+fi;
+for process in $(pgrep -a 'openvpn$'); do
+    out="$out $(echo \\"$process\\" | grep -Po '(?<=--remote\ )(\S*)|(?<=--config\ )(.*)(?=\.conf|\.ovpn)' | xargs basename)"
+done
+echo "$out"
+unset IFS


### PR DESCRIPTION
I've also added support for (hopefully most) VPNs instantiated via network-manager and systemd

This should retain back-compatibility with the previous functionality apart from two minor display changes:
* The pluralisation of VPN 
* The omission of `down` in the absence of a VPN

Let me know if moving from Bourne Shell to BASH is a problem, Bourne gave me a few issues I didn't have time to debug