### PR TITLE
Make player-mpris-tail able to handle position in the current track

### DIFF
--- a/polybar-scripts/player-mpris-tail/player-mpris-tail.py
+++ b/polybar-scripts/player-mpris-tail/player-mpris-tail.py
@@ -130,6 +130,12 @@ class Player:
             'title'  : '',
             'track'  : 0
         }
+
+        self._rate = 1.
+        self._positionAtLastUpdate = 0.
+        self._timeAtLastUpdate = time.time()
+        self._positionTimerRunning = False
+
         self._metadata = None
         self.status = 'stopped'
         self.icon = ICON_NONE
@@ -154,6 +160,7 @@ class Player:
         self._playerRaise     = self._media_interface.get_dbus_method('Raise', dbus_interface=None)
         self._signals = {}
 
+        self.refreshPosition()
         self.refreshStatus()
         self.refreshMetadata()
 
@@ -195,6 +202,7 @@ class Player:
         try:
             self.status = str(self._getProperty('org.mpris.MediaPlayer2.Player', 'PlaybackStatus')).lower()
             self.updateIcon()
+            self.checkPositionTimer()
         except dbus.exceptions.DBusException:
             self.disconnect()
 
@@ -271,11 +279,39 @@ class Player:
             status = str(properties[dbus.String('PlaybackStatus')]).lower()
             if status != self.status:
                 self.status = status
+                self.checkPositionTimer()
                 self.updateIcon()
                 updated = True
-        
+        if NEEDS_POSITION and dbus.String('Rate') in properties:
+            rate = properties[dbus.String('Rate')]
+            if rate != self._rate:
+                self._rate = rate
+                self.refreshPosition()
+
         if updated:
+            self.refreshPosition()
             self.printStatus()
+
+    def checkPositionTimer(self):
+        if NEEDS_POSITION and self.status == 'playing' and not self._positionTimerRunning:
+            self._positionTimerRunning = True
+            GLib.timeout_add_seconds(1, self._positionTimer)
+
+    def _positionTimer(self):
+        self.printStatus()
+        self._positionTimerRunning = self.status == 'playing'
+        return self._positionTimerRunning
+
+    def refreshPosition(self):
+        time_us = self._getProperty('org.mpris.MediaPlayer2.Player', 'Position')
+        self._timeAtLastUpdate = time.time()
+        self._positionAtLastUpdate = time_us / 1000000
+
+    def _getPosition(self):
+        if self.status == 'playing':
+            return self._positionAtLastUpdate + self._rate * (time.time() - self._timeAtLastUpdate)
+        else:
+            return self._positionAtLastUpdate
 
     def _statusReplace(self, match, metadata):
         tag = match.group('tag')
@@ -318,6 +354,8 @@ class Player:
     def printStatus(self):
         if self.status in [ 'playing', 'paused' ]:
             metadata = { **self.metadata, 'icon': self.icon, 'icon-reversed': self.icon_reversed }
+            if NEEDS_POSITION:
+                metadata['position'] = time.strftime("%M:%S", time.gmtime(self._getPosition()))
             # replace metadata tags in text
             text = re.sub(FORMAT_REGEX, lambda match: self._statusReplace(match, metadata), FORMAT_STRING)
             # restore polybar tag formatting and replace any remaining metadata tags after that
@@ -408,6 +446,8 @@ parser.add_argument('--icon-none', default='')
 args = parser.parse_args()
 
 FORMAT_STRING = re.sub(r'%\{(.*?)\}(.*?)%\{(.*?)\}', r'􏿿p􏿿\1􏿿p􏿿\2􏿿p􏿿\3􏿿p􏿿', args.format)
+NEEDS_POSITION = "{position}" in FORMAT_STRING
+
 TRUNCATE_STRING = args.truncate_text
 ICON_PLAYING = args.icon_playing
 ICON_PAUSED = args.icon_paused


### PR DESCRIPTION
The `{position}` tag can now be used to get the progress on the current track and display it. For now, only display as a time is supported, but I can add display as a progress bar if it people wish so.
The code tries not to make too frequent calls to dbus, and is disabled when not using it in order to save battery.