### PR TITLE
Remove unnecessary use of sudo in updates-void

### DIFF
--- a/polybar-scripts/updates-void/README.md
+++ b/polybar-scripts/updates-void/README.md
@@ -3,15 +3,6 @@
 A script that shows if there are updates for Void Linux.
 
 
-## Configuration
-
-You have to add the `xbps-install` command to the `/etc/sudoers` NOPASSWD of your user:
-
-```
-user ALL=(ALL) NOPASSWD: /usr/bin/xbps-install
-```
-
-
 ## Module
 
 ```ini

--- a/polybar-scripts/updates-void/updates-void.sh
+++ b/polybar-scripts/updates-void/updates-void.sh
@@ -1,8 +1,6 @@
 #!/bin/sh
 
-if sudo /usr/bin/xbps-install -S > /dev/null 2>&1; then
-    updates=$(/usr/bin/xbps-install -un 2> /dev/null | wc -l)
-fi
+updates=$(xbps-install -Mun 2> /dev/null | wc -l)
 
 if [ -n "$updates" ] && [ "$updates" -gt 0 ]; then
     echo "# $updates"


### PR DESCRIPTION
Checking for updates doesn't require any special privileges, the script is safer like this.