### PR TITLE
readme: added budlabs/polify to see also

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,6 @@ Is this your first time here? You should definitely take a look at these scripts
 
 ## See also these other user repositories:
 
-* [budlabs/polify](https://github.com/budlabs/polify): A utility that makes it easier to manage and work with polybars IPC-modules.
 * [vyachkonovalov/polybar-gmail](https://github.com/vyachkonovalov/polybar-gmail): A Polybar module to show unread messages from Gmail
 * [0nse/now_playing](https://github.com/0nse/now_playing): Output the currently scrobbling song
 * [dakuten/taskwarrior-polybar](https://github.com/dakuten/taskwarrior-polybar): merely just a script showing the most urgent task and allowing it to be marked done
@@ -94,3 +93,5 @@ Is this your first time here? You should definitely take a look at these scripts
 * [dietervanhoof/polybar-spotify-controls](https://github.com/dietervanhoof/polybar-spotify-controls): set of modules provides controls for spotify
 * [unode/polypomo](https://github.com/unode/polypomo): Minimalist pomodoro style timer
 * [marioortizmanero/polybar-pulseaudio-control](https://github.com/marioortizmanero/polybar-pulseaudio-control): A feature-full polybar module to control pulseaudio
+* [budlabs/polify](https://github.com/budlabs/polify): A utility that makes it easier to manage and work with polybars IPC-modules
+

--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ Is this your first time here? You should definitely take a look at these scripts
 
 ## See also these other user repositories:
 
+* [budlabs/polify](https://github.com/budlabs/polify): A utility that makes it easier to manage and work with polybars IPC-modules.
 * [vyachkonovalov/polybar-gmail](https://github.com/vyachkonovalov/polybar-gmail): A Polybar module to show unread messages from Gmail
 * [0nse/now_playing](https://github.com/0nse/now_playing): Output the currently scrobbling song
 * [dakuten/taskwarrior-polybar](https://github.com/dakuten/taskwarrior-polybar): merely just a script showing the most urgent task and allowing it to be marked done


### PR DESCRIPTION
I just made my script `polify` public, and thought it somehow belonged in this collection. But since it is more of a utility then a script in the scripts directory of this repo i added it to the 'see also' section of the readme. I have some "modules"/scripts that use polify, that i can push later if you guys think it fits.