### PR TITLE
fixed weather variable scope

### DIFF
--- a/polybar-scripts/openweathermap-detailed/openweathermap-detailed.sh
+++ b/polybar-scripts/openweathermap-detailed/openweathermap-detailed.sh
@@ -28,6 +28,7 @@ KEY=""
 CITY=""
 UNITS="metric"
 SYMBOL="°"
+weather=""
 
 API="https://api.openweathermap.org/data/2.5"
 


### PR DESCRIPTION
Hi, script: openweathermap-detailed.sh was invalid - it was trying to echo some values taken from "weather" variable (containing JSON from OpenWeather API), but "weather" variable was not accessible in it's scope.

I have fixed it by declaring empty weather variable at the beginning of script.