### PR TITLE
Fix error output in rua upgrade

### DIFF
--- a/polybar-scripts/updates-arch-aur/updates-arch-aur.sh
+++ b/polybar-scripts/updates-arch-aur/updates-arch-aur.sh
@@ -4,7 +4,7 @@ if ! updates=$(yay -Qum 2> /dev/null | wc -l); then
 # if ! updates=$(cower -u 2> /dev/null | wc -l); then
 # if ! updates=$(trizen -Su --aur --quiet | wc -l); then
 # if ! updates=$(pikaur -Qua 2> /dev/null | wc -l); then
-# if ! updates=$(rua upgrade --printonly | wc -l); then
+# if ! updates=$(rua upgrade --printonly 2> /dev/null | wc -l); then
     updates=0
 fi
 

--- a/polybar-scripts/updates-arch-combined/updates-arch-combined.sh
+++ b/polybar-scripts/updates-arch-combined/updates-arch-combined.sh
@@ -8,7 +8,7 @@ if ! updates_aur=$(yay -Qum 2> /dev/null | wc -l); then
 # if ! updates_aur=$(cower -u 2> /dev/null | wc -l); then
 # if ! updates_aur=$(trizen -Su --aur --quiet | wc -l); then
 # if ! updates_aur=$(pikaur -Qua 2> /dev/null | wc -l); then
-# if ! updates_aur=$(rua upgrade --printonly | wc -l); then
+# if ! updates_aur=$(rua upgrade --printonly 2> /dev/null | wc -l); then
     updates_aur=0
 fi
 


### PR DESCRIPTION
`rua upgrade --printonly` will sometimes output a rust error (for instance when no internet connection is present)
These commits void that output while returning 0 for the number outdated repositories.