### PR TITLE
Specifying a date string in options

### DIFF
--- a/polybar-scripts/popup-calendar/popup-calendar.sh
+++ b/polybar-scripts/popup-calendar/popup-calendar.sh
@@ -6,10 +6,6 @@ YAD_WIDTH=222  # 222 is minimum possible value
 YAD_HEIGHT=193 # 193 is minimum possible value
 DATE=$(date +"%a %d %H:%M")
 
-POPUP=
-
-
-
 case "$1" in
 --popup)
     if [ "$(xdotool getwindowfocus getwindowname)" = "yad-calendar" ]; then

--- a/polybar-scripts/popup-calendar/popup-calendar.sh
+++ b/polybar-scripts/popup-calendar/popup-calendar.sh
@@ -4,7 +4,11 @@ BAR_HEIGHT=22  # polybar height
 BORDER_SIZE=1  # border size from your wm settings
 YAD_WIDTH=222  # 222 is minimum possible value
 YAD_HEIGHT=193 # 193 is minimum possible value
-DATE="$(date +"%a %d %H:%M")"
+DATE=$(date +"%a %d %H:%M")
+
+POPUP=
+
+
 
 case "$1" in
 --popup)
@@ -36,6 +40,9 @@ case "$1" in
         --title="yad-calendar" --borders=0 >/dev/null &
     ;;
 *)
+    if [[ -n $1 ]]; then
+        DATE=$( date "+$1" )
+    fi
     echo "$DATE"
     ;;
 esac

--- a/polybar-scripts/popup-calendar/popup-calendar.sh
+++ b/polybar-scripts/popup-calendar/popup-calendar.sh
@@ -37,7 +37,7 @@ case "$1" in
     ;;
 *)
     if [ -n "$1" ]; then
-        DATE=$( date +$1 )
+        DATE=$( date "+$1" )
     fi
     echo "$DATE"
     ;;

--- a/polybar-scripts/popup-calendar/popup-calendar.sh
+++ b/polybar-scripts/popup-calendar/popup-calendar.sh
@@ -36,7 +36,7 @@ case "$1" in
         --title="yad-calendar" --borders=0 >/dev/null &
     ;;
 *)
-    if [[ -n $1 ]]; then
+    if [[ ! -z $1 ]]; then
         DATE=$( date "+$1" )
     fi
     echo "$DATE"

--- a/polybar-scripts/popup-calendar/popup-calendar.sh
+++ b/polybar-scripts/popup-calendar/popup-calendar.sh
@@ -36,8 +36,8 @@ case "$1" in
         --title="yad-calendar" --borders=0 >/dev/null &
     ;;
 *)
-    if [[ ! -z $1 ]]; then
-        DATE=$( date "+$1" )
+    if [ -n "$1" ]; then
+        DATE=$( date +$1 )
     fi
     echo "$DATE"
     ;;


### PR DESCRIPTION
The popup-calendar script has a default date string, but specifying a different one by editing the script isn't very convenient, so it's better to set it with an argument