### PR TITLE
battery-combined-tlp: support laptops with one battery

### DIFF
--- a/polybar-scripts/battery-combined-tlp/battery-combined-tlp.sh
+++ b/polybar-scripts/battery-combined-tlp/battery-combined-tlp.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
 
-battery=$(sudo tlp-stat -b | grep "Charge total" |  tr -d -c "[:digit:],.")
+battery=$(sudo tlp-stat -b | tac | grep -m 1 "Charge" |  tr -d -c "[:digit:],.")
 
 echo "# $battery %"


### PR DESCRIPTION
"Charge total" doesn't exist in laptops with one battery, TLP simply displays the "Charge" for the single battery.

The output is purposefully reversed to find the first match backwards, whether that's "Charge total" or simply "Charge" in cases where "Charge total" doesn't exist.