### PR TITLE
player-mpris-tail - Fixed issues with malformed metadata

### DIFF
--- a/polybar-scripts/player-mpris-tail/player-mpris-tail.py
+++ b/polybar-scripts/player-mpris-tail/player-mpris-tail.py
@@ -265,6 +265,9 @@ class Player:
     def _parseMetadata(self):
         if self._metadata != None:
             artist = _getProperty(self._metadata, 'xesam:artist', [''])
+            # If we get a string, artist[0] returns the first character.
+            if type(artist) is str:
+                artist = [artist]
             if artist != None and len(artist):
                 self.metadata['artist'] = re.sub(SAFE_TAG_REGEX, """\1\1""", artist[0])
             else:
@@ -281,7 +284,8 @@ class Player:
             if not len(length):
                 length = str(_getProperty(self._metadata, 'mpris:length', ''))
             if len(length):
-                self.metadata['length'] = int(length)
+                # If we get a string formatted as a float, int(length) will ValueError, but int(float(length)) will not.
+                self.metadata['length'] = int(float(length))
             else:
                 self.metadata['length'] = 0
             self.metadata['genre']    = _getProperty(self._metadata, 'xesam:genre', '')


### PR DESCRIPTION
When receiving malformed metadata, this script would react in unexpected ways. I added a couple typecasts to make sure metadata comes in as expected.

Examples of malformed metadata:

When playing video in chromium, the Artist field would be represented with a string. This would then pass into line 269, and return only the first character of the Artist field, as it would be a string typecast as a list. Checking immediately beforehand if the artist is a string keeps this from happening.

When playing video in smplayer, (and this may be specific to some of my files,) length is returned as a float. Unfortunately, it's not a literal float, it's a string representation of a float. This means, when the script tries to cast length as an int, it crashes with a ValueError, since you can't have anything but integers when typecasting a string to an int. If we typecast it as a float first, it converts nicely regardless of the format.

--

I'm still relatively new to python, so please let me know if there's any issues with my code—Though, I can't think of any input that would cause issues with my changes and not with the existing script. Thanks!