### PR TITLE
Rewrite updates-fedora to work without sudo privileges

### DIFF
--- a/polybar-scripts/updates-fedora/README.md
+++ b/polybar-scripts/updates-fedora/README.md
@@ -4,10 +4,18 @@ A script that shows if there are updates for Fedora or `dnf` based distributions
 
 ![updates-fedora](screenshots/1.png)
 
-
 ## Configuration
 
-You have to add the `dnf` command to the `/etc/sudoers` NOPASSWD of your user:
+You can choose the `dnf` command used to retrieve the update information by 
+changing the number at the end of the `exec` line. Currently, there's two modes:
+
+1. updateinfo (default)
+   Shows uninstalled updates but doesn't show new dependencies
+2. update
+   Shows uninstalled updates and new dependencies
+
+For the second mode, you have to add the `dnf` command to the `/etc/sudoers` 
+NOPASSWD of your user:
 
 ```
 user ALL=(ALL) NOPASSWD: /usr/bin/dnf
@@ -18,6 +26,10 @@ user ALL=(ALL) NOPASSWD: /usr/bin/dnf
 ```ini
 [module/updates-fedora]
 type = custom/script
-exec = ~/polybar-scripts/updates-fedora.sh
+
+format = <label>
+label = %output%
+
+exec = ~/polybar-scripts/updates-fedora.sh 1
 interval = 600
 ```

--- a/polybar-scripts/updates-fedora/updates-fedora.sh
+++ b/polybar-scripts/updates-fedora/updates-fedora.sh
@@ -1,14 +1,33 @@
 #!/bin/sh
 
-dnf=$(env LC_ALL=C sudo dnf upgrade --refresh --assumeno 2> /dev/null)
+# Choose the dnf command this script use to retrieve updates information
+#
+# 1 - updateinfo 
+#     Shows uninstalled updates but doesn't show new dependencies
+# 2 - update (need sudo privilege)
+#     Shows uninstalled updates and new dependencies
 
-upgrade=$(echo "$dnf" | grep '^Upgrade ' | awk '{ print $2 }')
-install=$(echo "$dnf" | grep '^Install ' | awk '{ print $2 }')
+mode="$1"
 
-updates=$(( upgrade + install ))
+case "$mode" in
+  1)
+    updates=$(dnf -q updateinfo --list --updates 2> /dev/null | wc -l )
+    ;;
+  2)
+    dnf=$(env LC_ALL=C sudo dnf upgrade --assumeno 2> /dev/null)
+    
+    upgrade=$(echo "$dnf" | grep '^Upgrade ' | awk '{ print $2 }')
+    install=$(echo "$dnf" | grep '^Install ' | awk '{ print $2 }')
+
+    updates=$(( upgrade + install ))
+    ;;
+  *)
+    updates=$(dnf -q updateinfo --list --updates 2> /dev/null | wc -l )
+    ;;
+esac
 
 if [ "$updates" -gt 0 ]; then
-    echo "# $updates"
+  echo "$updates"
 else
-    echo ""
+  echo ""
 fi


### PR DESCRIPTION
Hi,

I've rewritten for my own use the updates-fedora module to work without adding `dnf` to `/etc/sudoers` and thought maybe that's something you'd be interested to merge in this repo :).  