### PR TITLE
Fix typo or accidental modification in the network-publicip script

### DIFF
--- a/polybar-scripts/network-publicip/info-publicip.sh
+++ b/polybar-scripts/network-publicip/info-publicip.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-echo "# $(curl -4 -sf ifconf4 ig.co)"
+echo "# $(curl -4 -sf ifconfig.co)"


### PR DESCRIPTION
$(curl -4 -sf ifconfig.co)" instead of 
$(curl -4 -sf ifconf4 ig.co)"