### PR TITLE
Add pkcon to retrieve update information

### DIFF
--- a/polybar-scripts/updates-apt/README.md
+++ b/polybar-scripts/updates-apt/README.md
@@ -1,7 +1,11 @@
 # Script: updates-apt
 
-A script that shows if there are updates available through the apt package manager on Ubuntu and Debian-based systems.
+A script that retrieves update information and shows if there are updates available through the apt package manager on Ubuntu and Debian-based systems.
 
+## Dependencies
+```bash
+  sudo apt install -y packagekit-tools
+```
 
 ## Module
 

--- a/polybar-scripts/updates-apt/updates-apt.sh
+++ b/polybar-scripts/updates-apt/updates-apt.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+pkcon refresh &>/dev/null
+
 updates=$(apt list --upgradable 2> /dev/null | grep -c upgradable);
 
 if [ "$updates" -gt 0 ]; then

--- a/polybar-scripts/updates-apt/updates-apt.sh
+++ b/polybar-scripts/updates-apt/updates-apt.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-pkcon refresh &>/dev/null
+pkcon refresh >/dev/null 2>&1
 
 updates=$(apt list --upgradable 2> /dev/null | grep -c upgradable);
 


### PR DESCRIPTION
Currently, the script only tells you if there are any upgrades based on the cached information which, unless you run `sudo apt update`, will not be updated automatically. `pkcon` (which doesn't require `sudo` to execute) will do this automatically for you.