### PR TITLE
Fixes sunrise and sunset show time

### DIFF
--- a/polybar-scripts/openweathermap-fullfeatured/openweathermap-fullfeatured.sh
+++ b/polybar-scripts/openweathermap-fullfeatured/openweathermap-fullfeatured.sh
@@ -102,9 +102,9 @@ if [ -n "$current" ] && [ -n "$forecast" ]; then
     now=$(date +%s)
 
     if [ "$sun_rise" -gt "$now" ]; then
-        daytime=" $(get_duration "$((sun_rise-now))")"
+        daytime=" $(get_duration "$sun_rise")"
     elif [ "$sun_set" -gt "$now" ]; then
-        daytime=" $(get_duration "$((sun_set-now))")"
+        daytime=" $(get_duration "$sun_set")"
     else
         daytime=" $(get_duration "$((sun_rise-now))")"
     fi

--- a/polybar-scripts/openweathermap-fullfeatured/openweathermap-fullfeatured.sh
+++ b/polybar-scripts/openweathermap-fullfeatured/openweathermap-fullfeatured.sh
@@ -46,8 +46,8 @@ get_duration() {
     osname=$(uname -s)
 
     case $osname in
-        *BSD) date -r "$1" -u +%H:%M;;
-        *) date --date="@$1" -u +%H:%M;;
+        *BSD) date -r "$1" +%H:%M;;
+        *) date --date="@$1" +%H:%M;;
     esac
 
 }


### PR DESCRIPTION
The openweather fullfeatured script does not correctly show the sunrise and sunset now, as the time returned from the API is not actually shown to the user. Furthermore, the script converts the timezone to UTC. These commits makes sure that the correct sunrise and sunset is used, and that the current timezone is shown to the user.