### PR TITLE
player-cmus: handle no file information

### DIFF
--- a/polybar-scripts/player-cmus/player-cmus.sh
+++ b/polybar-scripts/player-cmus/player-cmus.sh
@@ -2,33 +2,37 @@
 
 if info=$(cmus-remote -Q 2> /dev/null); then
 	status=$(echo "$info" | grep -v "set " | grep -v "tag " | grep "status " | cut -d ' ' -f 2)
-	
+
 	if [ "$status" = "playing" ] || [ "$status" = "paused" ] || [ "$status" = "stopped" ]; then
 		title=$(echo "$info" | grep -v 'set ' | grep " title " | cut -d ' ' -f 3-)
 		artist=$(echo "$info" | grep -v 'set ' | grep " artist " | cut -d ' ' -f 3-)
 		position=$(echo "$info" | grep -v "set " | grep -v "tag " | grep "position " | cut -d ' ' -f 2)
 		duration=$(echo "$info" | grep -v "set " | grep -v "tag " | grep "duration " | cut -d ' ' -f 2)
-		
-		if [ "$duration" -ge 0 ]; then
-			pos_minutes=$(printf "%02d" $((position / 60)))
-			pos_seconds=$(printf "%02d" $((position % 60)))
 
-			dur_minutes=$(printf "%02d" $((duration / 60)))
-			dur_seconds=$(printf "%02d" $((duration % 60)))
+		if [ "$artist" ] || [ "$title" ]; then
+			if [ "$duration" -ge 0 ]; then
+				pos_minutes=$(printf "%02d" $((position / 60)))
+				pos_seconds=$(printf "%02d" $((position % 60)))
 
-			info_string="| $pos_minutes:$pos_seconds / $dur_minutes:$dur_seconds" 
-		fi
-		
-		info_string="$artist - $title $info_string"
-		
-		if [ "$status" = "playing" ]; then
-			echo "#1 $info_string"
-		elif [ "$status" = "paused" ]; then
-			echo "#2 $info_string"
-		elif [ "$status" = "stopped" ]; then 
-			echo "#3 $info_string"
+				dur_minutes=$(printf "%02d" $((duration / 60)))
+				dur_seconds=$(printf "%02d" $((duration % 60)))
+
+				info_string="| $pos_minutes:$pos_seconds / $dur_minutes:$dur_seconds"
+			fi
+
+			info_string="$artist - $title $info_string"
+
+			if [ "$status" = "playing" ]; then
+				echo "#1 $info_string"
+			elif [ "$status" = "paused" ]; then
+				echo "#2 $info_string"
+			elif [ "$status" = "stopped" ]; then
+				echo "#3 $info_string"
+			else
+				echo ""
+			fi
 		else
-			echo ""
+			echo "";
 		fi
 	else
 		echo ""

--- a/polybar-scripts/player-cmus/player-cmus.sh
+++ b/polybar-scripts/player-cmus/player-cmus.sh
@@ -32,7 +32,7 @@ if info=$(cmus-remote -Q 2> /dev/null); then
 				echo ""
 			fi
 		else
-			echo "";
+			echo ""
 		fi
 	else
 		echo ""


### PR DESCRIPTION
When CMUS is started for the first time, cmus-remote doesn't return
any track data, which means $duration is an empty string. This causes
the script to fail with an error on line 12 when it tries to evaluate
$duration as an integer.

The fix is to only print any information if we have either a title or
an artist, which means we probably also have a duration as well.