### PR TITLE
Add mpris_player_control link to the repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,4 +117,4 @@ Is this your first time here? You should definitely take a look at these scripts
 * [jbirnick/polybar-todoist](https://github.com/jbirnick/polybar-todoist): Displays amount of Todoist tasks of each priority.
 * [PrayagS/polybar-spotify](https://github.com/PrayagS/polybar-spotify): Spotify status and controls module for Polybar with text scrolling
 * [Hackesta/polybar-speedtest](https://github.com/HackeSta/polybar-speedtest): speedtest.net Module for Polybar
-* [MaxdSre/mpris-player-control](https://github.com/MaxdSre/mpris-player-control): powerfull MPRIS players control script for Polybar
+* [MaxdSre/mpris-player-control](https://github.com/MaxdSre/mpris-player-control): Control player via MPRIS D-Bus interface 

--- a/README.md
+++ b/README.md
@@ -117,3 +117,4 @@ Is this your first time here? You should definitely take a look at these scripts
 * [jbirnick/polybar-todoist](https://github.com/jbirnick/polybar-todoist): Displays amount of Todoist tasks of each priority.
 * [PrayagS/polybar-spotify](https://github.com/PrayagS/polybar-spotify): Spotify status and controls module for Polybar with text scrolling
 * [Hackesta/polybar-speedtest](https://github.com/HackeSta/polybar-speedtest): speedtest.net Module for Polybar
+* [MaxdSre/mpris-player-control](https://github.com/MaxdSre/mpris-player-control): powerfull MPRIS players control script for Polybar


### PR DESCRIPTION
It is a Shell script, and is designed to work with Polybar, but can also be used alone.

## Features

1. Support media player implement with MPRIS DBus interface (VLC/cmus/Spotify/Audacious/Clementine/Rhythmbox ...);
2. Support Web browser (Google Chrome/Chromium/Brave/Mozilla Firefox ...);
3. Support play action (Play/Pause/PlayPause/Stop);
4. Support track position seek (backward/forward), position set;
5. Support player sink volume action (mute/unmute/up/down);
6. Support current track info display via notification deamon;
7. Support player session reset;
8. Support multi players selection menu when session is empty;
9. Support current player instance process kill;
10. Support Spotify official client advertisement mute until normal track playing (just click 'next' icon (nerd font uf9ab) on Polybar mpris bar);
11. Polybar mpris bar show/hide/restart action;
12. Notification with corresponding player icon if existed in icon theme *Papirus*;