### PR TITLE
Add my Toggl.com time tracker widget to the list

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,3 +118,4 @@ Is this your first time here? You should definitely take a look at these scripts
 * [PrayagS/polybar-spotify](https://github.com/PrayagS/polybar-spotify): Spotify status and controls module for Polybar with text scrolling
 * [Hackesta/polybar-speedtest](https://github.com/HackeSta/polybar-speedtest): speedtest.net Module for Polybar
 * [MaxdSre/mpris-player-control](https://github.com/MaxdSre/mpris-player-control): Control player via MPRIS D-Bus interface 
+* [maksmeshkov/toggl_polybar](https://github.com/maksmeshkov/toggl_polybar): Information about current running task for toggl.com time tracker users


### PR DESCRIPTION
It's a simple widget that uses toggl.com API to get your current running task info and display it.