### PR TITLE
system-fan-speed: fix empty speed

### DIFF
--- a/polybar-scripts/system-fan-speed/system-fan-speed.sh
+++ b/polybar-scripts/system-fan-speed/system-fan-speed.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-speed=$(sensors | grep fan1 | cut -d " " -f 9)
+speed=$(sensors | grep fan1 | awk '{print $2; exit}')
 
 if [ "$speed" != "" ]; then
     speed_round=$(echo "scale=1;$speed/1000" | bc -l )


### PR DESCRIPTION
Fix issue with speed expression returning empty string instead of integer.