### PR TITLE
I created an improved version of taskwarrior-polybar

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Is this your first time here? You should definitely take a look at these scripts
 * [vyachkonovalov/polybar-gmail](https://github.com/vyachkonovalov/polybar-gmail): A Polybar module to show unread messages from Gmail
 * [vyachkonovalov/bar-protonmail](https://github.com/vyachkonovalov/bar-protonmail): A Waybar/Polybar module for ProtonMail
 * [0nse/now_playing](https://github.com/0nse/now_playing): Output the currently scrobbling song
-* [DRKblade/polybar-warrior](https://github.com/DRKblade/polybar-warrior): A script to browse through your tasks and mark them as done. An improvement from taskwarrior-polybar
+* [DRKblade/polybar-warrior](https://github.com/DRKblade/polybar-warrior): A script to browse through your tasks and mark them as done.
 * [dakuten/taskwarrior-polybar](https://github.com/dakuten/taskwarrior-polybar): Merely just a script showing the most urgent task and allowing it to be marked done
 * [quelotic/polybarModules](https://github.com/quelotic/polybarModules): Scripts for mail and caffeine
 * [vyp/scripts](https://github.com/vyp/scripts): A script to show focused, occupied, free and urgent herbstluftwm tags in polybar

--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ Is this your first time here? You should definitely take a look at these scripts
 * [vyachkonovalov/polybar-gmail](https://github.com/vyachkonovalov/polybar-gmail): A Polybar module to show unread messages from Gmail
 * [vyachkonovalov/bar-protonmail](https://github.com/vyachkonovalov/bar-protonmail): A Waybar/Polybar module for ProtonMail
 * [0nse/now_playing](https://github.com/0nse/now_playing): Output the currently scrobbling song
+* [DRKblade/polybar-warrior](https://github.com/DRKblade/polybar-warrior): A script to browse through your tasks and mark them as done. An improvement from taskwarrior-polybar
 * [dakuten/taskwarrior-polybar](https://github.com/dakuten/taskwarrior-polybar): Merely just a script showing the most urgent task and allowing it to be marked done
 * [quelotic/polybarModules](https://github.com/quelotic/polybarModules): Scripts for mail and caffeine
 * [vyp/scripts](https://github.com/vyp/scripts): A script to show focused, occupied, free and urgent herbstluftwm tags in polybar


### PR DESCRIPTION
The module [taskwarrior-polybar](https://github.com/dakuten/taskwarrior-polybar) only display a single task to polybar. The user can't view any other task unless they finish the current task and mark it done.

With this script, multiple tasks can be viewed by left clicking the module and can be marked done by right clicking. Before the action is carried out, a message is displayed for 2 second in which the user can cancel the action.