### PR TITLE
notification-xkcd: Added error handling for no internet

### DIFF
--- a/polybar-scripts/notification-xkcd/notification-xkcd.py
+++ b/polybar-scripts/notification-xkcd/notification-xkcd.py
@@ -31,7 +31,10 @@ except FileNotFoundError:
 
 newComic = False
 while True:
-	status = requests.get('https://www.xkcd.com/' + str(latest + 1) + '/').status_code
+	try:
+		status = requests.get('https://www.xkcd.com/' + str(latest + 1) + '/').status_code
+	except requests.exceptions.ConnectionError:
+		status = 404
 
 	if status == 200:
 		latest += 1


### PR DESCRIPTION
This pull request removes the error thrown when there isn't any internet available, and instead shows the latest comic number stored on disk.