### PR TITLE
player-mpris-tail: fixed blacklist bug in onChangedProperties

### DIFF
--- a/polybar-scripts/player-mpris-tail/player-mpris-tail.py
+++ b/polybar-scripts/player-mpris-tail/player-mpris-tail.py
@@ -55,6 +55,8 @@ class PlayerManager:
         else:
             # If we don't know this player, get its name and add it
             bus_name = self.getBusNameFromOwner(sender)
+            if bus_name is None:
+                return
             self.addPlayer(bus_name, sender)
             player = self.players[sender]
             player.onPropertiesChanged(interface, properties, signature)


### PR DESCRIPTION
I run player-mpris-tail.py and add chrome into blacklist. However, the module output changed while chrome player status changed. Although chrome is in the blacklist, it does not check in  ``onChangedProperties``, and chrome will be recognized as the new player.