### PR TITLE
system-bluetooth-bluetoothctl: Remove pipe

### DIFF
--- a/polybar-scripts/system-bluetooth-bluetoothctl/system-bluetooth-bluetoothctl.sh
+++ b/polybar-scripts/system-bluetooth-bluetoothctl/system-bluetooth-bluetoothctl.sh
@@ -8,8 +8,8 @@ bluetooth_print() {
             devices_paired=$(bluetoothctl paired-devices | grep Device | cut -d ' ' -f 2)
             counter=0
 
-            echo "$devices_paired" | while read -r line; do
-                device_info=$(bluetoothctl info "$line")
+            for device in $devices_paired; do
+                device_info=$(bluetoothctl info "$device")
 
                 if echo "$device_info" | grep -q "Connected: yes"; then
                     device_alias=$(echo "$device_info" | grep "Alias" | cut -d ' ' -f 2-)


### PR DESCRIPTION
Replaces a pipe into a "`while read`"-statement with a simple for loop.
This has the advantage that a new subshell is not created because of the pipe, meaning the counter variable can be used outside of the loop. Also, i'd argue it's easier to read.