### PR TITLE
Added support for multi monitor setups to herbstluftwm workspace info

### DIFF
--- a/polybar-scripts/info-hlwm-workspaces/info-hlwm-workspaces.sh
+++ b/polybar-scripts/info-hlwm-workspaces/info-hlwm-workspaces.sh
@@ -18,26 +18,33 @@ herbstclient --idle "tag_*" 2>/dev/null | {
             for i in "${tags[@]}" ; do
                 # Read the prefix from each tag and render them according to that prefix
                 case ${i:0:1} in
-                    '#')
-                        # the tag is viewed on the bar's monitor and is focused
-                        # TODO Add your formatting tags for focused workspaces
-                        ;;
-                    '+')
-                        # the tag is viewed on the bar's monitor, but is not focused
-                        # TODO Add your formatting tags for viewed but unfocused tags
-                        ;;
-                    '!')
-                        # ! the tag contains an urgent window
-                        # TODO Add your formatting tags for workspaces with the urgent hint
-                        ;;
                     '.')
                         # the tag is empty
-                        # TODO Add your formatting tags for visible but not focused workspaces
+                        # TODO Add your formatting tags
                         ;;
-                    *)
-                        # default including not empty tags and tags viewed on another monitor (: - %)
-                        # TODO Add your formatting tags for tags that or not currently viewed
-                        # or displayed on another monitor
+                    ':')
+                        # the tag is not empty
+                        # TODO Add your formatting tags
+                        ;;
+                    '+')
+                        # the tag is viewed on the specified MONITOR, but this monitor is not focused.
+                        # TODO Add your formatting tags
+                        ;;
+                    '#')
+                        # the tag is viewed on the specified MONITOR and it is focused.
+                        # TODO Add your formatting tags
+                        ;;
+                    '-')
+                        # the tag is viewed on a different MONITOR, but this monitor is not focused.
+                        # TODO Add your formatting tags
+                        ;;
+                    '%')
+                        # the tag is viewed on a different MONITOR and it is focused.
+                        # TODO Add your formatting tags
+                        ;;
+                    '!')
+                        # the tag contains an urgent window
+                        # TODO Add your formatting tags
                         ;;
                 esac
 

--- a/polybar-scripts/info-hlwm-workspaces/info-hlwm-workspaces.sh
+++ b/polybar-scripts/info-hlwm-workspaces/info-hlwm-workspaces.sh
@@ -1,40 +1,51 @@
 #!/usr/bin/env bash
 
+# Multi monitor support. Needs MONITOR environment variable to be set for each instance of polybar
+# If MONITOR environment variable is not set this will default to monitor 0
+# Check https://github.com/polybar/polybar/issues/763
+MON_IDX="0"
+mapfile -t MONITOR_LIST < <(polybar --list-monitors | cut -d":" -f1)
+for (( i=0; i<$((${#MONITOR_LIST[@]})); i++ )); do
+  [[ ${MONITOR_LIST[${i}]} == "$MONITOR" ]] && MON_IDX="$i"
+done;
+
 herbstclient --idle "tag_*" 2>/dev/null | {
 
     while true; do
         # Read tags into $tags as array
-        IFS=$'\t' read -ra tags <<< "$(herbstclient tag_status)"
+        IFS=$'\t' read -ra tags <<< "$(herbstclient tag_status "${MON_IDX}")"
         {
             for i in "${tags[@]}" ; do
                 # Read the prefix from each tag and render them according to that prefix
                 case ${i:0:1} in
                     '#')
-                        # the tag is viewed on the focused monitor
+                        # the tag is viewed on the bar's monitor and is focused
                         # TODO Add your formatting tags for focused workspaces
                         ;;
-                    ':')
-                        # : the tag is not empty
-                        # TODO Add your formatting tags for occupied workspaces
+                    '+')
+                        # the tag is viewed on the bar's monitor, but is not focused
+                        # TODO Add your formatting tags for viewed but unfocused tags
                         ;;
                     '!')
                         # ! the tag contains an urgent window
                         # TODO Add your formatting tags for workspaces with the urgent hint
                         ;;
-                    '-')
-                        # - the tag is viewed on a monitor that is not focused
+                    '.')
+                        # the tag is empty
                         # TODO Add your formatting tags for visible but not focused workspaces
                         ;;
                     *)
-                        # . the tag is empty
-                        # There are also other possible prefixes but they won't appear here
-                        echo "%{F-}%{B-}" # Add your formatting tags for empty workspaces
+                        # default including not empty tags and tags viewed on another monitor (: - %)
+                        # TODO Add your formatting tags for tags that or not currently viewed
+                        # or displayed on another monitor
                         ;;
                 esac
 
-                echo "%{A1:herbstclient use ${i:1}:}  ${i:1}  %{A -u -o F- B-}"
+                # focus the monitor of the current bar before switching tags
+                echo "%{A1:herbstclient focus_monitor ${MON_IDX}; herbstclient use ${i:1}:}  ${i:1}  %{A -u -o F- B-}"
             done
 
+            # reset foreground and background color to default
             echo "%{F-}%{B-}"
         } | tr -d "\n"
 


### PR DESCRIPTION
This adds support for using the info-hlwm-workspaces.sh script on a multi monitor setup.

It expects MONITOR environment variable to be set for each instance of polybar. If the MONITOR variable is not set this will still be working, however there will be no distinction between the different monitors.
This enables formatting the tags considering whether the current monitor is focused or not.

Also if one clicks on one of the tags in polybar, the script will ensure that the monitor is focused where the user clicked the tag. This prevents the effect that if one clicks a tag on an unfocused monitor, the tag will change on the other, focused monitor. This is eventually unexpected behaviour.