### PR TITLE
pipewire-microphone: add pipewire-microphone

### DIFF
--- a/polybar-scripts/pipewire-microphone/README.md
+++ b/polybar-scripts/pipewire-microphone/README.md
@@ -1,0 +1,27 @@
+# Script: pipewire-microphone
+
+A script for showing and toggling the mute state of the PipeWire default source (microphone). Based on [pulseaudio-microphone](https://github.com/polybar/polybar-scripts/tree/master/polybar-scripts/pulseaudio-microphone).
+
+## Usage
+
+Use the left click for toggling the state.
+
+## Dependencies
+
+- POSIX-compatible shell interpreter
+- coreutils
+- pactl (libpulse)
+- awk
+- sed
+- pw-cat (pipewire) 
+
+## Module
+
+``` ini
+[module/pipewire-microphone]
+type = custom/script
+exec = $HOME/.config/polybar/polybar-scripts/polybar-scripts/pipewire-microphone/pipewire-microphone.sh
+tail = true
+click-left = $HOME/.config/polybar/polybar-scripts/polybar-scripts/pipewire-microphone/pipewire-microphone.sh --toggle &
+```
+

--- a/polybar-scripts/pipewire-microphone/README.md
+++ b/polybar-scripts/pipewire-microphone/README.md
@@ -24,4 +24,3 @@ exec = $HOME/.config/polybar/polybar-scripts/polybar-scripts/pipewire-microphone
 tail = true
 click-left = $HOME/.config/polybar/polybar-scripts/polybar-scripts/pipewire-microphone/pipewire-microphone.sh --toggle &
 ```
-

--- a/polybar-scripts/pipewire-microphone/pipewire-microphone.sh
+++ b/polybar-scripts/pipewire-microphone/pipewire-microphone.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env sh
+
+get_mic_default() {
+    pw-cat --record --list-targets | sed -n -E "1 s/^.*: (.*)/\1/p"
+}
+
+is_mic_muted() {
+    mic_name="$(get_mic_default)"
+
+    pactl list sources |
+        awk -v mic_name="${mic_name}" '{
+            if ($0 ~ "Name: " mic_name) {
+                matched_mic_name = 1;
+            } else if (matched_mic_name && /Mute/) {
+                print $2;
+                exit;
+            }
+        }'
+}
+
+get_mic_status() {
+    is_muted="$(is_mic_muted)"
+
+    if [ "${is_muted}" = "yes" ]; then
+        printf "%s\n" ""
+    else
+        printf "%s\n" ""
+    fi
+}
+
+listen() {
+    get_mic_status
+
+    LANG=EN; pactl subscribe | while read -r event; do
+        if printf "%s\n" "${event}" | grep --quiet "source" || printf "%s\n" "${event}" | grep --quiet "server"; then
+            get_mic_status
+        fi
+    done
+}
+
+toggle() {
+    pactl set-source-mute @DEFAULT_SOURCE@ toggle
+}
+
+main() {
+    case "${1}" in
+        --toggle)
+            toggle
+            ;;
+        *)
+            listen
+            ;;
+    esac
+}
+
+main "${@}"

--- a/polybar-scripts/pipewire-microphone/pipewire-microphone.sh
+++ b/polybar-scripts/pipewire-microphone/pipewire-microphone.sh
@@ -7,7 +7,7 @@ get_mic_default() {
 is_mic_muted() {
     mic_name="$(get_mic_default)"
 
-    pactl list sources |
+    pactl list sources | \
         awk -v mic_name="${mic_name}" '{
             if ($0 ~ "Name: " mic_name) {
                 matched_mic_name = 1;


### PR DESCRIPTION
Add script for showing and toggling the mute state of the PipeWire default source (microphone). Based on [pulseaudio-microphone](https://github.com/polybar/polybar-scripts/tree/master/polybar-scripts/pulseaudio-microphone).