### PR TITLE
player-mpris-tail: add whitelist support

### DIFF
--- a/polybar-scripts/player-mpris-tail/README.md
+++ b/polybar-scripts/player-mpris-tail/README.md
@@ -50,6 +50,7 @@ The following arguments are supported:
 Argument | Description | Default
 ---|---|---
 -b, --blacklist   | Blacklist / Ignore the given player
+-w, --whitelist   | Whitelist / Permit the given player
 -f, --format      | Use the given `format` string                               | `{icon} {artist} - {title}`
 --truncate-text   | Use the given string as the end of truncated text           | `…`
 --icon-playing    | Use the given text as the playing icon                      | `⏵`


### PR DESCRIPTION
Add whitelist support for module player-mpris-tail:
1. drop duplicated word '**be**' in option ``--blacklist`` help message.
2. change ``PlayerManager.__init__(blacklist = [], connect = True)`` into ``PlayerManager.__init__(filter_list, block_mode = True, connect = True)``, and remove list default parameter value, which is not a good [pattern](https://stackoverflow.com/questions/1132941/least-astonishment-and-the-mutable-default-argument).
3. keep option ``--blacklist`` and add option ``--whitelist`` for command line backward.