### PR TITLE
Fixed shebang for updates-pacman-aurhelper

### DIFF
--- a/polybar-scripts/updates-pacman-aurhelper/updates-pacman-aurhelper.sh
+++ b/polybar-scripts/updates-pacman-aurhelper/updates-pacman-aurhelper.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 if ! updates_arch=$(checkupdates 2> /dev/null | wc -l ); then
     updates_arch=0

--- a/polybar-scripts/updates-pacman-aurhelper/updates-pacman-aurhelper.sh
+++ b/polybar-scripts/updates-pacman-aurhelper/updates-pacman-aurhelper.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 if ! updates_arch=$(checkupdates 2> /dev/null | wc -l ); then
     updates_arch=0
@@ -13,7 +13,7 @@ if ! updates_aur=$(yay -Qum 2> /dev/null | wc -l); then
     updates_aur=0
 fi
 
-updates=$(("$updates_arch" + "$updates_aur"))
+updates=$((updates_arch + updates_aur))
 
 if [ "$updates" -gt 0 ]; then
     echo "# $updates"


### PR DESCRIPTION
The shebang in _updates-pacman-aurhelper_ is incorrect as it assumes that the user has sh symlinked to bash. That is the case by default in arch, but its still not a safe assumption.

Specifically, the line that is using a bash'ism is the following:
```sh
updates=$(("$updates_arch" + "$updates_aur"))
```