### PR TITLE
Added a link to polybar-wireguard repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ Is this your first time here? You should definitely take a look at these scripts
 * [MaxdSre/mpris-player-control](https://github.com/MaxdSre/mpris-player-control): Control player via MPRIS D-Bus interface
 * [maksmeshkov/toggl_polybar](https://github.com/maksmeshkov/toggl_polybar): Information about current running task for toggl.com time tracker users
 * [shervinsahba/polybar-vpn-controller](https://github.com/shervinsahba/polybar-vpn-controller): Manage your VPN via this polybar module
+* [mil-ad/polybar-wireguard](https://github.com/mil-ad/polybar-wireguard): Display and control Wireguard VPN interfaces
 * [madhat2r/polybar-i3-window](https://github.com/madhat2r/polybar-i3-window): A Polybar module to show i3 window title that can handle multi-monitors
 * [sTiKyt/polybar-onlinestatus](https://github.com/sTiKyt/polybar-onlinestatus): Indicator of your internet connection
 * [mt-inside/polybar-lmsensors](https://github.com/mt-inside/polybar-lmsensors): Print the values of specified lmsensors


### PR DESCRIPTION
Adds [mil-ad/polybar-wireguard](https://github.com/mil-ad/polybar-wireguard) to the list of user repos.

This is a simple script that displays the current active Wireguard VPN. Mouse clicks can be mapped to connect/disconnect.

