### PR TITLE
player-mpris-simple:add script to auto_and_forth in i3wm

### DIFF
--- a/polybar-scripts/player-mpris-simple/i3_back_and_forth.py
+++ b/polybar-scripts/player-mpris-simple/i3_back_and_forth.py
@@ -1,0 +1,36 @@
+
+#!/usr/bin/python
+#author :  with <dc198424601@outlook.com>
+
+import os
+import json
+import re
+
+def get_windows():
+    #return dict containing workspace and window:{'3':['xfce4-terminal']}
+    classPattern=re.compile("class': '(.*?)',")#get the class name of window
+    tree_dict={}
+    p=os.popen('i3-msg -t get_tree')
+    treeData=json.load(p)
+    for workspace in treeData['nodes'][1]['nodes'][1]['nodes']:
+        tree_dict[workspace['name']]=[]
+        windows=classPattern.findall(str(workspace))
+        for i in windows:
+            tree_dict[workspace['name']].append(i)
+    return tree_dict
+
+
+def get_current_workspace():
+    p=os.popen('i3-msg -t get_workspaces')
+    treeData=json.load(p)
+    for i in treeData:
+        if i['focused']==True:
+            return i['name']
+
+
+if __name__=="__main__":
+    current_player=os.popen("playerctl metadata|cut -d' ' -f1|uniq").read().replace('\n','')
+    if current_player not in (get_windows()[get_current_workspace()]):
+        os.system("i3-msg -t command [class={}] focus".format(current_player))
+    else:
+        os.system("i3-msg -t command workspace back_and_forth")


### PR DESCRIPTION
one python script to easily auto_back_and_forth in i3wm, we can bind this script with left-click. click first to jump to the workspace containing the program that is playing the media. If we are already there, then click will help us jump back .
```shell
[module/player-mpris-simple]
type=custom/script
........
click-left=python ~/.config/polybar/scripts/mymusic_back_and_forth.py
```