### PR TITLE
info-wifionice: Add failsafe for VPN usage

### DIFF
--- a/polybar-scripts/info-wifionice/info-wifionice.sh
+++ b/polybar-scripts/info-wifionice/info-wifionice.sh
@@ -1,7 +1,14 @@
 #!/bin/sh
 
+icon="#"
+
 if [ "$(iwgetid -r)" = "WIFIonICE" ]; then
     wifionice=$(curl -sf https://iceportal.de/api1/rs/status)
+
+    if [ "$(echo "$wifionice" | jq -e 2>/dev/null)" != 0 ]; then
+        echo "$icon In-train portal unreachable"
+        exit 0
+    fi
 
     if [ "$(echo "$wifionice" | jq .connection)" = "true" ]; then
         wifionice_speed=$(echo "$wifionice" | jq .speed)
@@ -27,7 +34,7 @@ if [ "$(iwgetid -r)" = "WIFIonICE" ]; then
             station_delay=""
         fi
 
-        echo "# $station_arrival$station_delay - $station_name, Gl. $station_track$wifionice_speed"
+        echo "$icon $station_arrival$station_delay - $station_name, Gl. $station_track$wifionice_speed"
     fi
 else
     echo ""


### PR DESCRIPTION
The current info-wifionice script checks whether the current SSID is `WIFIonICE`, then curls a URL from the train's intranet and json-parses that. This fails when the entire network traffic is routed through a VPN, since in that case, the wifi SSID matches but curling the URL returns content from outside the train's intranet.

I added a fix which checks for non-json content and shows a helpful message if necessary.

The curl response outside the train network is `<html> <head> <meta http-equiv="refresh" content="0; URL=https://www.bahn.de/service/zug/ice-portal"> </head></html>`, and trying to json-parse this without this fix will display `parse error: Invalid numeric literal at line 1, column 7` in polybar.