### PR TITLE
Simplify and fix pipewire-simple regex

### DIFF
--- a/polybar-scripts/pipewire-simple/pipewire-simple.sh
+++ b/polybar-scripts/pipewire-simple/pipewire-simple.sh
@@ -2,13 +2,13 @@
 
 getDefaultSink() {
     defaultSink=$(pactl info | awk -F : '/Default Sink:/{print $2}')
-    description=$(pactl list sinks | sed -n "/${defaultSink}/,/Description/p; /Description/q" | sed -n 's/^.*Description: \(.*\)$/\1/p')
+    description=$(pactl list sinks | sed -n "/${defaultSink}/,/Description/s/^\s*Description: \(.*\)/\1/p")
     echo "${description}"
 }
 
 getDefaultSource() {
     defaultSource=$(pactl info | awk -F : '/Default Source:/{print $2}')
-    description=$(pactl list sources | sed -n "/${defaultSource}/,/Description/p; /Description/q" | sed -n 's/^.*Description: \(.*\)$/\1/p')
+    description=$(pactl list sources | sed -n "/${defaultSource}/,/Description/s/^\s*Description: \(.*\)/\1/p")
     echo "${description}"
 }
 


### PR DESCRIPTION
There was an issue with the regex not properly matching the name of the device from pactl.  This should fix it (and is probably a better implementation). 