### PR TITLE
Fixed mono visualizations from not being able to appear

### DIFF
--- a/polybar-scripts/info-cava/info-cava.py
+++ b/polybar-scripts/info-cava/info-cava.py
@@ -56,7 +56,7 @@ with open(cava_conf, 'w') as cava_conf_file:
         'method=raw\n'
         'data_format=ascii\n'
        f'ascii_max_range={conf_ascii_max_range}\n'
-        'bar_delimiter=32'
+        'bar_delimiter=32\n'
         + conf_channels
     )
 


### PR DESCRIPTION
Missing newline character prevented conf_channels from being added to temp config file properly, and Cava's default stereo visualization would always be used as a fallback instead.