### PR TITLE
updates-flatpak: output correction about update numbers

### DIFF
--- a/polybar-scripts/updates-flatpak/updates-flatpak.sh
+++ b/polybar-scripts/updates-flatpak/updates-flatpak.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-updates=$(flatpak update 2>/dev/null | tail -n +5 | grep -Ev "^$|^Proceed|^Nothing"|wc -l)
+updates=$(flatpak update 2>/dev/null | tail -n +5 | grep -Ecv "^$|^Proceed|^Nothing")
 
 if [ "$updates" -gt 0 ]; then
     echo "flatpak: $updates"

--- a/polybar-scripts/updates-flatpak/updates-flatpak.sh
+++ b/polybar-scripts/updates-flatpak/updates-flatpak.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-updates=$(echo 'n' | flatpak update 2>/dev/null | tail -n +5 | head -2 | wc -l)
+updates=$(flatpak update 2>/dev/null | tail -n +5 | egrep -v "^$|^Proceed|^Nothing"|wc -l)
 
 if [ "$updates" -gt 0 ]; then
     echo "flatpak: $updates"

--- a/polybar-scripts/updates-flatpak/updates-flatpak.sh
+++ b/polybar-scripts/updates-flatpak/updates-flatpak.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-updates=$(flatpak update 2>/dev/null | tail -n +5 | egrep -v "^$|^Proceed|^Nothing"|wc -l)
+updates=$(flatpak update 2>/dev/null | tail -n +5 | grep -Ev "^$|^Proceed|^Nothing"|wc -l)
 
 if [ "$updates" -gt 0 ]; then
     echo "flatpak: $updates"


### PR DESCRIPTION
Adjusted the output to display the correct value of updates , removing the Nothing, Proceed and empty lines to list the correct value of updates without over or under numbering