### PR TITLE
Modified player-mpris-simple to slice metadata

### DIFF
--- a/polybar-scripts/player-mpris-simple/player-mpris-simple.sh
+++ b/polybar-scripts/player-mpris-simple/player-mpris-simple.sh
@@ -2,10 +2,19 @@
 
 player_status=$(playerctl status 2> /dev/null)
 
-if [ "$player_status" = "Playing" ]; then
-    echo "#1 $(playerctl metadata artist) - $(playerctl metadata title)"
-elif [ "$player_status" = "Paused" ]; then
-    echo "#2 $(playerctl metadata artist) - $(playerctl metadata title)"
+#this function slice the artist length to 15 characters and 20 characters for the title preventing it from taking all the polybar space
+print_metadata () {
+    player_title=$(playerctl metadata title 2> /dev/null)
+    player_artist=$(playerctl metadata artist 2> /dev/null)
+    if [ "$player_status" = "Playing" ]; then
+        echo "#1 ${player_artist::15} - ${player_title::20}"
+    elif [ "$player_status" = "Paused" ]; then
+        echo "#2 ${player_artist::15} - ${player_title::20}"
+    fi
+}
+
+if [ "$player_status" = "" ]; then
+    echo "#3 No player found"
 else
-    echo "#3"
+    print_metadata
 fi


### PR DESCRIPTION
Modified player-mpris-simple to slice metadata preventing it from using all the polybar.
I realized that some songs might be too long and take a lot of space.