### PR TITLE
wifi-ssid

### DIFF
--- a/polybar-scripts/wifi-ssid/README.md
+++ b/polybar-scripts/wifi-ssid/README.md
@@ -1,0 +1,20 @@
+# Script: wifi-ssid
+
+A shell script that shows the wifi ssid connected.
+
+Displays the name of the current WiFi network in the Polybar. Updates the network name every 10 seconds and displays the result in the format defined in the Polybar configuration. It's useful for having a quick look at the name of the WiFi network you're connected to.
+
+
+## Module
+
+```ini
+[module/wifi-shell]
+type = custom/script
+
+exec = ~/polybar-scripts/wifi-ssid.sh
+
+interval = 10
+
+label = %output%
+format = <label>
+```

--- a/polybar-scripts/wifi-ssid/README.md
+++ b/polybar-scripts/wifi-ssid/README.md
@@ -10,7 +10,6 @@ Displays the name of the current WiFi network in the Polybar. Updates the networ
 ```ini
 [module/wifi-shell]
 type = custom/script
-
 exec = ~/polybar-scripts/wifi-ssid.sh
 
 interval = 10

--- a/polybar-scripts/wifi-ssid/wifi-ssid.sh
+++ b/polybar-scripts/wifi-ssid/wifi-ssid.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+device="wlan0"
+connection=$(nmcli device show $device | grep "GENERAL.CONNECTION:" | awk '{print $2}')
+
+if [[ -n $connection ]]; then
+    echo $connection
+else
+    echo "No WiFi Connection"
+fi


### PR DESCRIPTION
Displays the name of the current WiFi network in the Polybar. Updates the network name every 10 seconds and displays the result in the format defined in the Polybar configuration. It's useful for having a quick look at the name of the WiFi network you're connected to.