### PR TITLE
Fix sh errors with POSIX read

### DIFF
--- a/polybar-scripts/network-networkmanager/network-networkmanager.sh
+++ b/polybar-scripts/network-networkmanager/network-networkmanager.sh
@@ -63,7 +63,7 @@ trap exit INT
 while true; do
     network_print
 
-    timeout 60s nmcli monitor | while read -r; do
+    timeout 60s nmcli monitor | while read -r REPLY; do
         network_print
     done &
 

--- a/polybar-scripts/system-bluetooth-bluetoothctl/system-bluetooth-bluetoothctl.sh
+++ b/polybar-scripts/system-bluetooth-bluetoothctl/system-bluetooth-bluetoothctl.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 bluetooth_print() {
-    bluetoothctl | while read -r; do
+    bluetoothctl | while read -r REPLY; do
         if [ "$(systemctl is-active "bluetooth.service")" = "active" ]; then
             printf '#1'
 


### PR DESCRIPTION
If `#!/bin/sh` is linked to dash or any strictly POSIX compliant shell, these scripts will give a `read: arg count` error as the standard `read` utility requires at least one variable's name. These changes fix this issue.