### PR TITLE
Fix bug in network-networkmanager script showing loopback interface

### DIFF
--- a/polybar-scripts/network-networkmanager/network-networkmanager.sh
+++ b/polybar-scripts/network-networkmanager/network-networkmanager.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 network_print() {
-    connection_list=$(nmcli -t -f name,type,device,state connection show --order name --active 2>/dev/null | grep -v ':bridge:')
+    connection_list=$(nmcli -t -f name,type,device,state connection show --order name --active 2>/dev/null | grep -v ':bridge:\|:lo:')
     counter=0
 
     if [ -n "$connection_list" ] && [ "$(echo "$connection_list" | wc -l)" -gt 0  ]; then


### PR DESCRIPTION
Currently the script prints a loopback interface if it exists alongside WiFi, Ethernet etc. This commit fixes this behaviour.