### PR TITLE
system-bluetooth-bluetoothctl: add bluetooth battery reporting

### DIFF
--- a/polybar-scripts/system-bluetooth-bluetoothctl/README.md
+++ b/polybar-scripts/system-bluetooth-bluetoothctl/README.md
@@ -4,6 +4,8 @@ A shell script which displays the status of bluetooth and the paired devices.
 
 Use the toggle option to power on the controller and try to connect to all paired devices or to disconnect all connections and turn off the controller.
 
+Note that bluetooth battery level reporting is an experimental feature which needs to be enabled by uncommenting and setting the `Experimental` line in `/etc/bluetooth/main.conf` to `true` and then restarting the `bluetooth.service`.
+
 ![system-bluetooth-bluetoothctl](screenshots/1.png)
 
 

--- a/polybar-scripts/system-bluetooth-bluetoothctl/system-bluetooth-bluetoothctl.sh
+++ b/polybar-scripts/system-bluetooth-bluetoothctl/system-bluetooth-bluetoothctl.sh
@@ -13,11 +13,24 @@ bluetooth_print() {
 
                 if echo "$device_info" | grep -q "Connected: yes"; then
                     device_alias=$(echo "$device_info" | grep "Alias" | cut -d ' ' -f 2-)
+                    device_address=$(echo "$device" | sed -r 's/[:]+/_/g')
+                    device_battery=$(dbus-send --print-reply=literal --system --dest=org.bluez /org/bluez/hci0/dev_"$device_address" org.freedesktop.DBus.Properties.Get string:"org.bluez.Battery1" string:"Percentage" | sed 's/.*byte //')
 
-                    if [ $counter -gt 0 ]; then
-                        printf ", %s" "$device_alias"
+                    if [ "$device_battery" -gt 90 ]; then
+                        battery_icon="#21"
+                    elif [ "$device_battery" -gt 60 ]; then
+                        battery_icon="#22"
+                    elif [ "$device_battery" -gt 35 ]; then
+                        battery_icon="#23"
+                    elif [ "$device_battery" -gt 10 ]; then
+                        battery_icon="#24"
                     else
-                        printf " %s" "$device_alias"
+                        battery_icon="#25"
+                    fi
+                    if [ $counter -gt 0 ]; then
+                        printf ", %s %s  %s%%" "$device_alias" "$battery_icon" "$device_battery"
+                    else
+                        printf " %s %s  %s%%" "$device_alias" "$battery_icon" "$device_battery"
                     fi
 
                     counter=$((counter + 1))

--- a/polybar-scripts/system-bluetooth-bluetoothctl/system-bluetooth-bluetoothctl.sh
+++ b/polybar-scripts/system-bluetooth-bluetoothctl/system-bluetooth-bluetoothctl.sh
@@ -13,24 +13,26 @@ bluetooth_print() {
 
                 if echo "$device_info" | grep -q "Connected: yes"; then
                     device_alias=$(echo "$device_info" | grep "Alias" | cut -d ' ' -f 2-)
-                    device_address=$(echo "$device" | sed -r 's/[:]+/_/g')
-                    device_battery=$(dbus-send --print-reply=literal --system --dest=org.bluez /org/bluez/hci0/dev_"$device_address" org.freedesktop.DBus.Properties.Get string:"org.bluez.Battery1" string:"Percentage" | sed 's/.*byte //')
+                    device_battery=$(echo "$device_info" | grep "Battery" | awk -F'[()]' '{print $2}')
 
-                    if [ "$device_battery" -gt 90 ]; then
-                        battery_icon="#21"
-                    elif [ "$device_battery" -gt 60 ]; then
-                        battery_icon="#22"
-                    elif [ "$device_battery" -gt 35 ]; then
-                        battery_icon="#23"
-                    elif [ "$device_battery" -gt 10 ]; then
-                        battery_icon="#24"
-                    else
-                        battery_icon="#25"
+                    if [ ! -z "$device_battery" ]; then
+                        if [ "$device_battery" -gt 90 ]; then
+                            battery_icon="#21"
+                        elif [ "$device_battery" -gt 60 ]; then
+                            battery_icon="#22"
+                        elif [ "$device_battery" -gt 35 ]; then
+                            battery_icon="#23"
+                        elif [ "$device_battery" -gt 10 ]; then
+                            battery_icon="#24"
+                        else
+                            battery_icon="#25"
+                        fi
+                        device_alias+=" $battery_icon   $device_battery%"
                     fi
                     if [ $counter -gt 0 ]; then
-                        printf ", %s %s  %s%%" "$device_alias" "$battery_icon" "$device_battery"
+                        printf ", %s" "$device_alias"
                     else
-                        printf " %s %s  %s%%" "$device_alias" "$battery_icon" "$device_battery"
+                        printf " %s" "$device_alias"
                     fi
 
                     counter=$((counter + 1))

--- a/polybar-scripts/system-bluetooth-bluetoothctl/system-bluetooth-bluetoothctl.sh
+++ b/polybar-scripts/system-bluetooth-bluetoothctl/system-bluetooth-bluetoothctl.sh
@@ -15,7 +15,7 @@ bluetooth_print() {
                     device_alias=$(echo "$device_info" | grep "Alias" | cut -d ' ' -f 2-)
                     device_battery=$(echo "$device_info" | grep "Battery" | awk -F'[()]' '{print $2}')
 
-                    if [ ! -z "$device_battery" ]; then
+                    if [ -n "$device_battery" ]; then
                         if [ "$device_battery" -gt 90 ]; then
                             battery_icon="#21"
                         elif [ "$device_battery" -gt 60 ]; then
@@ -27,7 +27,7 @@ bluetooth_print() {
                         else
                             battery_icon="#25"
                         fi
-                        device_alias+=" $battery_icon   $device_battery%"
+                        device_alias="${device_alias} $battery_icon   $device_battery%"
                     fi
                     if [ $counter -gt 0 ]; then
                         printf ", %s" "$device_alias"


### PR DESCRIPTION
This commit adds the printing of the Bluetooth device battery percentage to the script.