### PR TITLE
fix pipewire-microphone

### DIFF
--- a/polybar-scripts/pipewire-microphone/README.md
+++ b/polybar-scripts/pipewire-microphone/README.md
@@ -6,7 +6,6 @@ A script for showing and toggling the mute state of the PipeWire default microph
 ## Dependencies
 
 * pactl (libpulse)
-* pw-cat (pipewire)
 
 
 ## Module

--- a/polybar-scripts/pipewire-microphone/pipewire-microphone.sh
+++ b/polybar-scripts/pipewire-microphone/pipewire-microphone.sh
@@ -1,41 +1,39 @@
 #!/bin/sh
 
-_get_mic_default() {
+get_mic_default() {
     pactl info | awk '/Default Source:/ {print $3}'
 }
 
-_is_mic_muted() {
-    pactl get-source-mute "$(_get_mic_default)" | awk '{print $2}'
+is_mic_muted() {
+    pactl get-source-mute "$(get_mic_default)" | awk '{print $2}'
 }
 
-_get_mic_status() {
-    if [ "$(_is_mic_muted)" = "yes" ]; then
+get_mic_status() {
+    if [ "$(is_mic_muted)" = "yes" ]; then
         printf "%s\n" "#1"
     else
         printf "%s\n" "#2"
     fi
 }
 
-_listen() {
-    _get_mic_status
+listen() {
+    get_mic_status
     LANG=EN; pactl subscribe | while read -r event; do
         if printf "%s\n" "${event}" | grep -qE '(source|server)'; then
-            _get_mic_status
+            get_mic_status
         fi
     done
 }
 
-_toggle() {
+toggle() {
     pactl set-source-mute @DEFAULT_SOURCE@ toggle
 }
 
 case "${1}" in
     --toggle)
-        _toggle
+        toggle
         ;;
     *)
-        _listen
+        listen
         ;;
 esac
-
-# vim: ts=4 sw=4 et:

--- a/polybar-scripts/pipewire-microphone/pipewire-microphone.sh
+++ b/polybar-scripts/pipewire-microphone/pipewire-microphone.sh
@@ -1,52 +1,41 @@
 #!/bin/sh
 
-get_mic_default() {
-    pw-cat --record --list-targets | sed -n -E "1 s/^.*: (.*)/\1/p"
+_get_mic_default() {
+    pactl info | awk '/Default Source:/ {print $3}'
 }
 
-is_mic_muted() {
-    mic_name="$(get_mic_default)"
-
-    pactl list sources | \
-        awk -v mic_name="${mic_name}" '{
-            if ($0 ~ "Name: " mic_name) {
-                matched_mic_name = 1;
-            } else if (matched_mic_name && /Mute/) {
-                print $2;
-                exit;
-            }
-        }'
+_is_mic_muted() {
+    pactl get-source-mute "$(_get_mic_default)" | awk '{print $2}'
 }
 
-get_mic_status() {
-    is_muted="$(is_mic_muted)"
-
-    if [ "${is_muted}" = "yes" ]; then
+_get_mic_status() {
+    if [ "$(_is_mic_muted)" = "yes" ]; then
         printf "%s\n" "#1"
     else
         printf "%s\n" "#2"
     fi
 }
 
-listen() {
-    get_mic_status
-
+_listen() {
+    _get_mic_status
     LANG=EN; pactl subscribe | while read -r event; do
-        if printf "%s\n" "${event}" | grep --quiet "source" || printf "%s\n" "${event}" | grep --quiet "server"; then
-            get_mic_status
+        if printf "%s\n" "${event}" | grep -qE '(source|server)'; then
+            _get_mic_status
         fi
     done
 }
 
-toggle() {
+_toggle() {
     pactl set-source-mute @DEFAULT_SOURCE@ toggle
 }
 
-case "$1" in
+case "${1}" in
     --toggle)
-        toggle
+        _toggle
         ;;
     *)
-        listen
+        _listen
         ;;
 esac
+
+# vim: ts=4 sw=4 et:


### PR DESCRIPTION
The `--list-targets` option was removed from `pw-cat` in [ecff225b](https://gitlab.freedesktop.org/pipewire/pipewire/-/commit/ecff225b11a29ecc9754e67de7a462f529e8e2a6), which broke the script (#436).
In my opinion it's not really necessary, since it can be done with `pactl`.
Other changes mainly concern style/efficiency.