### PR TITLE
pulseaudio-microphone: using @DEFAULT_SOURCE@ instead

### DIFF
--- a/polybar-scripts/pulseaudio-microphone/pulseaudio-microphone.sh
+++ b/polybar-scripts/pulseaudio-microphone/pulseaudio-microphone.sh
@@ -22,23 +22,20 @@ listen() {
 
 toggle() {
   MUTED=$(pacmd list-sources | awk '/\*/,EOF {print}' | awk '/muted/ {print $2; exit}')
-  DEFAULT_SOURCE=$(pacmd list-sources | awk '/\*/,EOF {print $3; exit}')
 
   if [ "$MUTED" = "yes" ]; then
-      pactl set-source-mute "$DEFAULT_SOURCE" 0
+      pactl set-source-mute @DEFAULT_SOURCE@ 0
   else
-      pactl set-source-mute "$DEFAULT_SOURCE" 1
+      pactl set-source-mute @DEFAULT_SOURCE@ 1
   fi
 }
 
 increase() {
-  DEFAULT_SOURCE=$(pacmd list-sources | awk '/\*/,EOF {print $3; exit}')
-  pactl set-source-volume "$DEFAULT_SOURCE" +5%
+  pactl set-source-volume @DEFAULT_SOURCE@ +5%
 }
 
 decrease() {
-  DEFAULT_SOURCE=$(pacmd list-sources | awk '/\*/,EOF {print $3; exit}')
-  pactl set-source-volume "$DEFAULT_SOURCE" -5%
+  pactl set-source-volume @DEFAULT_SOURCE@ -5%
 }
 
 case "$1" in


### PR DESCRIPTION
When I was setting up the pulseaudio-microphone on my new laptop, it couldn't recognize my internal microphone. It was returning a random string that I can't remember. So, I decided to change the `$DEFAULT_SOURCE` variable to `@DEFAULT_SOURCE@`, which is an internal value of `pactl`