### PR TITLE
notification-spacex: migrate from spacexdata to launchlibrary

### DIFF
--- a/polybar-scripts/notification-spacex/notification-spacex.sh
+++ b/polybar-scripts/notification-spacex/notification-spacex.sh
@@ -1,14 +1,18 @@
 #!/bin/sh
 
-spacex_launch=$(curl -sf https://api.spacexdata.com/v5/launches/next)
+spacex_launch=$(curl -sf "https://ll.thespacedevs.com/2.2.0/launch/upcoming/?lsp__name=SpaceX&status__ids=1&limit=1")
 
 if [ -n "$spacex_launch" ]; then
-    spacex_precision=$(echo "$spacex_launch" | jq -r '.date_precision' )
-    spacex_timestamp=$(echo "$spacex_launch" | jq -r '.date_unix' )
+    spacex_precision=$(printf "%s" "$spacex_launch" | jq -r '.results[0].net_precision.abbrev' )
+    spacex_timestamp=$(date +"%s" --date "$(printf "%s" "$spacex_launch" | jq -r '.results[0].net' )")
     spacex_duration=$((spacex_timestamp - $(date +%s)))
 
-    if [ "$spacex_precision" = "hour" ] && [ "$spacex_duration" -lt 43200 ] && [ "$spacex_duration" -gt 0 ]; then
-        echo "# $(date +"%H:%M" -u --date @$spacex_duration)"
+    if [ "$spacex_precision" = "HR" ] || [ "$spacex_precision" = "MIN" ] || [ "$spacex_precision" = "SEC" ]; then
+        if [ "$spacex_duration" -lt 43200 ] && [ "$spacex_duration" -gt 0 ]; then
+            echo "# $(date +"%H:%M" -u --date @$spacex_duration)"
+        else
+            echo ""
+        fi
     else
         echo ""
     fi


### PR DESCRIPTION
api.spacexdata.com is no longer updated. See https://github.com/r-spacex/SpaceX-API/pull/1329

Marking this as a draft for now because I'm waiting for the next launch to make sure the changes work correctly.