### PR TITLE
notification-spacex: Bugfix for when there are no upcoming launches

### DIFF
--- a/polybar-scripts/notification-spacex/notification-spacex.sh
+++ b/polybar-scripts/notification-spacex/notification-spacex.sh
@@ -4,10 +4,10 @@ spacex_launch=$(curl -sf "https://ll.thespacedevs.com/2.2.0/launch/upcoming/?lsp
 
 if [ -n "$spacex_launch" ]; then
     spacex_precision=$(printf "%s" "$spacex_launch" | jq -r '.results[0].net_precision.abbrev' )
-    spacex_timestamp=$(date +"%s" --date "$(printf "%s" "$spacex_launch" | jq -r '.results[0].net' )")
-    spacex_duration=$((spacex_timestamp - $(date +%s)))
 
     if [ "$spacex_precision" = "HR" ] || [ "$spacex_precision" = "MIN" ] || [ "$spacex_precision" = "SEC" ]; then
+        spacex_timestamp=$(date +"%s" --date "$(printf "%s" "$spacex_launch" | jq -r '.results[0].net' )")
+        spacex_duration=$((spacex_timestamp - $(date +%s)))
         if [ "$spacex_duration" -lt 43200 ] && [ "$spacex_duration" -gt 0 ]; then
             echo "# $(date +"%H:%M" -u --date @$spacex_duration)"
         else


### PR DESCRIPTION
This is a bugfix for my previous PR #449

When there are no upcoming launches, "jq" returns the string "null". Since the old version of the script directly recieved a timestamp, it silently cast it to a number 0 during calculations, but the new version uses the "date" command for parsing an ISO 8601 string, where this errors out instead.