### PR TITLE
Change "energy" to "charge" in battery-combined-udev.sh

### DIFF
--- a/polybar-scripts/battery-combined-udev/battery-combined-udev.sh
+++ b/polybar-scripts/battery-combined-udev/battery-combined-udev.sh
@@ -15,20 +15,20 @@ battery_print() {
         ac=$(cat "$PATH_AC/online")
     fi
 
-    if [ -f "$PATH_BATTERY_0/energy_now" ]; then
-        battery_level_0=$(cat "$PATH_BATTERY_0/energy_now")
+    if [ -f "$PATH_BATTERY_0/charge_now" ]; then
+        battery_level_0=$(cat "$PATH_BATTERY_0/charge_now")
     fi
 
-    if [ -f "$PATH_BATTERY_0/energy_full" ]; then
-        battery_max_0=$(cat "$PATH_BATTERY_0/energy_full")
+    if [ -f "$PATH_BATTERY_0/charge_full" ]; then
+        battery_max_0=$(cat "$PATH_BATTERY_0/charge_full")
     fi
 
-    if [ -f "$PATH_BATTERY_1/energy_now" ]; then
-        battery_level_1=$(cat "$PATH_BATTERY_1/energy_now")
+    if [ -f "$PATH_BATTERY_1/charge_now" ]; then
+        battery_level_1=$(cat "$PATH_BATTERY_1/charge_now")
     fi
 
-    if [ -f "$PATH_BATTERY_1/energy_full" ]; then
-        battery_max_1=$(cat "$PATH_BATTERY_1/energy_full")
+    if [ -f "$PATH_BATTERY_1/charge_full" ]; then
+        battery_max_1=$(cat "$PATH_BATTERY_1/charge_full")
     fi
 
     battery_level=$(("$battery_level_0 + $battery_level_1"))


### PR DESCRIPTION
The /sys/class/power_supply/ files seem to have been renamed to "charge_", using the script in its original form would throw division by zero errors, no values could be read under "energy_".