### PR TITLE
Add pulseaudio-bluetooth-headset

### DIFF
--- a/polybar-scripts/pulseaudio-bluetooth-headset/README.md
+++ b/polybar-scripts/pulseaudio-bluetooth-headset/README.md
@@ -1,0 +1,52 @@
+# Script: polybar-buds
+
+## Dependencies
+
+- pulseaudio
+- pulseaudio-bluetooth
+- bluez
+- bluez-utils
+
+## Configuration
+
+1. Open the env.sh file. You should see BT_HEADSET_NAME and BT_HEADSET_MAC as empty values.
+
+2. run the following command: pacmd list-cards
+
+3. search for the card that represents your bluetooth device (device must be connected at this point)
+
+4. copy the "name" value which should look like this (ignore the angle brackets and only copy the name):
+   name: <bluez_card.C4_SS_3A_FF_63_50>
+
+   Paste the name into the BT_HEADSET_NAME value in the env.sh file
+
+5. run: bluetoothctl devices Connected
+
+the output will look like so : Device D8:1F:22:9E:8B:30 HUAWEI FreeBuds Pro 3
+
+6. Copy the MAC address portion (ex: D8:1F:22:9E:8B:30)
+
+7. Paste the MAC address into the BT_HEADSET_MAC value in the env.sh
+
+## Controls
+
+Left-Click: will toggle between playback mode to mic mode
+Right-Click: will disconnect or connect your bluetooth headset
+
+## Module
+
+ini ```
+[module/headset]
+type = custom/script
+exec = source ~/.config/polybar/scripts/polybar-buds/env.sh && ~/.config/polybar/scripts/polybar-buds/polybar-buds.sh init
+click-left = source ~/.config/polybar/scripts/polybar-buds/env.sh && ~/.config/polybar/scripts/polybar-buds/polybar-buds.sh toggle
+click-right = source ~/.config/polybar/scripts/polybar-buds/env.sh && ~/.config/polybar/scripts/polybar-buds/polybar-buds.sh connect
+env-PLAYBACK_ICON=#1
+env-MIC_ICON=#2
+env-DISCONNECTED_ICON=#3
+label=" %output% "
+interval=2
+
+```
+
+```

--- a/polybar-scripts/pulseaudio-bluetooth-headset/polybar-buds/env.sh
+++ b/polybar-scripts/pulseaudio-bluetooth-headset/polybar-buds/env.sh
@@ -1,0 +1,23 @@
+#sets playback or mic mode. DO NOT TOUCH. Toggle is handled automatically by polybar
+export AUDIO_MODE=playback
+#sets connection state of mic. DO NOT TOUCH. Handled automatically.
+export BT_HEADSET_CONNECTED=true
+
+
+
+
+
+#Enter the name of the bluetooth headset. It is usually just the MAC Adress of the bluetooth device.
+# To find the "name" of the bluetooth device run the following command:
+#pacmd ls
+
+#All of the pulse audio channels will be listed. You just need to find the channel for your device. The name that you are looking for will look something like this
+#name: <bluez_card.C4_SS_3A_FF_63_50>
+
+#ignore the angle braces and copy the name inside of them.
+export BT_HEADSET_NAME=SOME_VALUE
+
+#run bluetoothctl devices to get a list of devices. Grab the mac address of your device and paste it to the field below
+#if no devices come up, run bluetoothctl scan on and then run bluetoothctl devices(assuming you have already done bluetooth setup in any capacity).
+export BT_HEADSET_MAC=SOME_VALUE
+

--- a/polybar-scripts/pulseaudio-bluetooth-headset/polybar-buds/polybar-buds.sh
+++ b/polybar-scripts/pulseaudio-bluetooth-headset/polybar-buds/polybar-buds.sh
@@ -1,0 +1,63 @@
+
+#!/bin/sh
+
+envFile=~/.config/polybar/scripts/polybar-buds/env.sh
+
+
+playback_icon="${PLAYBACK_ICON}"
+mic_icon="${MIC_ICON}"
+disconnected_icon="${DISCONNECTED_ICON}"
+
+changeMode() {
+  sed -i "s/AUDIO_MODE=$1/AUDIO_MODE=$2/g" $envFile 
+  AUDIO_MODE=$2
+  echo $AUDIO_MODE
+}
+
+changeConnected() {
+  sed -i "s/BT_HEADSET_CONNECTED=$1/BT_HEADSET_CONNECTED=$2/g" $envFile 
+  BT_HEADSET_CONNECTED=$2
+  echo $BT_HEADSET_CONNECTED
+}
+
+case $1 in 
+  toggle) 
+    if [ "$AUDIO_MODE" = playback ];
+    then
+      changeMode "$AUDIO_MODE" mic
+      pacmd set-card-profile $BT_HEADSET_NAME handsfree_head_unit
+    else
+      changeMode "$AUDIO_MODE" playback
+      pacmd set-card-profile $BT_HEADSET_NAME a2dp_sink
+    fi
+    ;;
+  init)
+    if [ "$BT_HEADSET_CONNECTED" = false ];
+    then
+      printf $disconnected_icon
+    else
+      case $AUDIO_MODE in
+        playback)
+          printf $playback_icon
+          ;;
+        mic)
+          printf $mic_icon
+          ;;
+      esac
+    fi
+    ;;
+  connect)
+    case $BT_HEADSET_CONNECTED in 
+      true)
+        bluetoothctl disconnect $BT_HEADSET_MAC 
+        changeConnected "$BT_HEADSET_CONNECTED" false
+        ;;
+      false)
+        bluetoothctl connect $BT_HEADSET_MAC
+        changeConnected "$BT_HEADSET_CONNECTED" true
+        ;;
+    esac
+    ;;
+esac
+
+


### PR DESCRIPTION
This is a script to manage bluetooth headsets using pulseaudio. It solves the problem of finicky auto detection between HFP and A2DP Sink profiles by making a toggle in polybar. This also allows users to immediately disconnect and reconnect their headsets.

A couple of caveats:

- the user must initially input the headset's MAC address, and name into the env.sh file.
- the user must have the headset connected to their computer in order to get the name of the device.