### PR TITLE
Adjusting the updateinfo parameter from --list to list only

### DIFF
--- a/polybar-scripts/updates-dnf/updates-dnf.sh
+++ b/polybar-scripts/updates-dnf/updates-dnf.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-updates=$(dnf updateinfo -q --list | wc -l)
+updates=$(dnf updateinfo -q list | wc -l)
 
 if [ "$updates" -gt 0 ]; then
     echo "# $updates"


### PR DESCRIPTION
In the new version of dnf the --list parameter was replaced by just list as can be seen below

dnf --version
dnf5 version 5.2.12.0

With --list
dnf updateinfo -q --list | wc -l 
Unknown argument "--list" for command "updateinfo". Add "--help" for more information about the arguments.
The argument is available for commands: repoquery. (Must be placed after the command.)


Only list
dnf updateinfo -q list | wc -l 
0