### PR TITLE
info-wifionice: add support for float-typed speed

### DIFF
--- a/polybar-scripts/info-wifionice/info-wifionice.sh
+++ b/polybar-scripts/info-wifionice/info-wifionice.sh
@@ -17,7 +17,7 @@ if { [ "$current_wifi" = "WIFIonICE" ] || [ "$current_wifi" = "WIFI@DB" ]; }; th
 
     if [ "$(echo "$wifionice" | jq .connection)" = "true" ]; then
         wifionice_speed=$(echo "$wifionice" | jq .speed)
-        if [ "$wifionice_speed" -ne 0 ]; then
+        if [ $(echo "${wifionice_speed} != 0" | bc) -eq 1 ]; then
             wifionice_speed=" - $wifionice_speed km/h"
         else
             wifionice_speed=""

--- a/polybar-scripts/info-wifionice/info-wifionice.sh
+++ b/polybar-scripts/info-wifionice/info-wifionice.sh
@@ -17,7 +17,7 @@ if { [ "$current_wifi" = "WIFIonICE" ] || [ "$current_wifi" = "WIFI@DB" ]; }; th
 
     if [ "$(echo "$wifionice" | jq .connection)" = "true" ]; then
         wifionice_speed=$(echo "$wifionice" | jq .speed)
-        if [ $(echo "${wifionice_speed} != 0" | bc) -eq 1 ]; then
+        if [ "$(echo "${wifionice_speed} != 0" | bc)" -eq 1 ]; then
             wifionice_speed=" - $wifionice_speed km/h"
         else
             wifionice_speed=""


### PR DESCRIPTION
Deutsche Bahn has blessed us with an extra decimal point for train travel speeds.
This breaks the current script which assumes that speeds are integers.

This PR adds support for float-typed speeds.