### PR TITLE
Add exaroth/i3-news to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ Is this your first time here? You should definitely take a look at these scripts
 #### News/Feeds
 * [zemmsoares/polybar-news](https://github.com/zemmsoares/polybar-news): Read news on your polybar
 * [nivit/polybar-module-news](https://github.com/nivit/polybar-module-news): This polybar module displays RSS/Atom feeds
+* [exaroth/i3-news](https://github.com/exaroth/i3-news): Add interactive news headlines from your favorite RSS feeds to Polybar.
 
 #### Blue light filter
 * [VineshReddy/polybar-redshift](https://github.com/VineshReddy/polybar-redshift): Change, display temperature and open/close Redshift


### PR DESCRIPTION
I3 News is an interactive RSS/Atom news headlines plugin -  compatible with i3status, i3blocks, polybar and waybar 

Detailed installation and configuration instructions are in the project README